### PR TITLE
Feature/add percentage ranking

### DIFF
--- a/app/Http/Controllers/MarketController.php
+++ b/app/Http/Controllers/MarketController.php
@@ -57,7 +57,6 @@ class MarketController extends Controller
 
     public function payStipend($season)
     {
-
         $pdo = DB::connection()->getPdo();
 
         $sql = "UPDATE banks SET money = (money+20) WHERE season_id = :season_id";
@@ -126,9 +125,12 @@ class MarketController extends Controller
         $lastValue = '1';
         $hiddenRank = 1;
 
-        $insert = $networth->map(function ($net) use ($stocks, $season, &$rank, &$lastValue, &$hiddenRank) {
-            if ($stocks->has($net->user_id)) {
+        $totalActivePlayers = $networth->reject(function ($value) {
+            return $value === null;
+        })->count();
 
+        $insert = $networth->map(function ($net) use ($stocks, $season, $totalActivePlayers, &$rank, &$lastValue, &$hiddenRank) {
+            if ($stocks->has($net->user_id)) {
                 if ($lastValue === $net->networth) {
                     $newRank = $rank;
                 } else {
@@ -139,15 +141,15 @@ class MarketController extends Controller
                 $hiddenRank++;
 
                 return [
-                    'user_id'   => $net->user_id,
-                    'season_id' => $season->id,
-                    'week'      => $season->current_week,
-                    'rank'      => $newRank,
-                    'networth'  => $net->networth,
-                    'stocks'    => $stocks[$net->user_id]
+                    'user_id'           => $net->user_id,
+                    'season_id'         => $season->id,
+                    'week'              => $season->current_week,
+                    'rank'              => $newRank,
+                    'rank_percentage'   => ceil($newRank / $totalActivePlayers * 100),
+                    'networth'          => $net->networth,
+                    'stocks'            => $stocks[$net->user_id]
                 ];
             }
-
         })->reject(function ($value) {
             return $value === null;
         })->toArray();

--- a/app/Models/Leaderboard.php
+++ b/app/Models/Leaderboard.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\RankPercentile;
 use App\WeeklyLeaderboards;
 
 class Leaderboard extends BaseModel
@@ -12,10 +13,18 @@ class Leaderboard extends BaseModel
         'stocks' => 'array'
     ];
 
+    protected $appends = [
+        'rank_percentile'
+    ];
+
     //=== RELATIONSHIPS ===//
     public function user()
     {
         return $this->belongsTo(User::class);
     }
     //=== METHODS ===//
+    public function getRankPercentileAttribute()
+    {
+        return (new RankPercentile($this))->calculate();
+    }
 }

--- a/app/Models/Leaderboard.php
+++ b/app/Models/Leaderboard.php
@@ -12,26 +12,10 @@ class Leaderboard extends BaseModel
         'stocks' => 'array'
     ];
 
-    protected $appends = [
-        'rank_percentage'
-    ];
-
     //=== RELATIONSHIPS ===//
     public function user()
     {
         return $this->belongsTo(User::class);
     }
     //=== METHODS ===//
-
-    //=== ATTRIBUTES ===//
-    public function getRankPercentageAttribute()
-    {
-        $total = (new WeeklyLeaderboards($this->season_id, $this->week))->count();
-
-        if ($total == 0) {
-            return 0;
-        }
-
-        return ceil($this->rank / $total * 100);
-    }
 }

--- a/app/RankPercentile.php
+++ b/app/RankPercentile.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App;
+
+use App\Models\Leaderboard;
+
+class RankPercentile
+{
+    protected $ranks = [1,5,10,25,50,75];
+
+    protected $leaderboard;
+
+    public function __construct(Leaderboard $leaderboard)
+    {
+        $this->leaderboard = $leaderboard;
+    }
+
+    public function calculate()
+    {
+        foreach ($this->ranks as $rank) {
+            if ($this->leaderboard->rank_percentage <= $rank) {
+                return $rank;
+            }
+        }
+
+        return 100;
+    }
+}

--- a/database/migrations/2020_09_05_022424_add_rank_percentage_to_leaderboard.php
+++ b/database/migrations/2020_09_05_022424_add_rank_percentage_to_leaderboard.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Models\Leaderboard;
+use App\WeeklyLeaderboards;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class AddRankPercentageToLeaderboard extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('leaderboard', function (Blueprint $table) {
+            $table->integer('rank_percentage')->after('rank')->index();
+        });
+
+        $this->seed();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('leaderboard', function (Blueprint $table) {
+            $table->drop('rank_percentage');
+        });
+    }
+
+    protected function seed()
+    {
+        $leaderboards = Leaderboard::query()->cursor();
+
+        $leaderboards->each(function (Leaderboard $leaderboard) {
+            $total = (new WeeklyLeaderboards($leaderboard->season_id, $leaderboard->week))->count();
+            $leaderboard->rank_percentage = $total > 0 ? ceil($leaderboard->rank / $total * 100) : 0;
+            $leaderboard->save();
+        });
+    }
+}

--- a/database/migrations/2020_09_05_022424_add_rank_percentage_to_leaderboard.php
+++ b/database/migrations/2020_09_05_022424_add_rank_percentage_to_leaderboard.php
@@ -41,7 +41,7 @@ class AddRankPercentageToLeaderboard extends Migration
 
         $leaderboards->each(function (Leaderboard $leaderboard) {
             $total = (new WeeklyLeaderboards($leaderboard->season_id, $leaderboard->week))->count();
-            $leaderboard->rank_percentage = $total > 0 ? ceil($leaderboard->rank / $total * 100) : 0;
+            $leaderboard->rank_percentage = $total > 0 ? ceil($leaderboard->rank / $total * 100) : 100;
             $leaderboard->save();
         });
     }


### PR DESCRIPTION
I've added a separate "rank_percentile" attribute that returns the group (e.g. 1, 5, 10, 25, 50, 75). The "rank_percentage" attribute now stores to the database, retaining the leaderboard's exact rank percentage (1-100).