### PR TITLE
Leaderboards paginate server side

### DIFF
--- a/app/Http/Controllers/LeaderboardController.php
+++ b/app/Http/Controllers/LeaderboardController.php
@@ -12,17 +12,18 @@ use Illuminate\Support\Facades\DB;
 
 class LeaderboardController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
         $season = Season::current();
         $houseguests = Houseguest::where('season_id', $season->id)->get();
 
         $leaderboard = Leaderboard::where('week', $season->current_week)
                                   ->where('season_id', $season->id)
+                                  ->search($request->search)
                                   ->with('user.banks')
                                   ->orderBy('rank')
                                   ->cacheFor(now()->addHours(24))
-                                  ->get();
+                                  ->paginate(100);
 
         return view('leaderboard', compact('houseguests', 'leaderboard', 'season'));
     }

--- a/app/Models/Leaderboard.php
+++ b/app/Models/Leaderboard.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\RankPercentile;
 use App\WeeklyLeaderboards;
+use Illuminate\Database\Eloquent\Builder;
 
 class Leaderboard extends BaseModel
 {
@@ -38,6 +39,20 @@ class Leaderboard extends BaseModel
         $query->whereHas('season', function ($query) {
             $query->where('status', 'ended');
         });
+    }
+
+    public function scopeSearch($query, $terms)
+    {
+        collect(explode(' ', $terms))->filter()->each(function ($term) use ($query) {
+            $term = "{$term}%";
+            $query->where(function (Builder $builder) use ($term) {
+                $builder->whereHas('user', function (Builder $builder) use ($term) {
+                    $builder->where('name', 'like', $term);
+                });
+            });
+        });
+
+        return $query;
     }
 
     //=== METHODS ===//

--- a/resources/js/components/leaderboard/LeaderboardTable.vue
+++ b/resources/js/components/leaderboard/LeaderboardTable.vue
@@ -1,11 +1,15 @@
 <template>
     <div class="leader-grid">
         <label class="label-hidden">Filter by Name:</label>
-        <input
-            class="input inline-width input-light mg-btm-md"
-            placeholder="Search user..."
-            v-model="filters.name.value"
-        />
+        <form method="GET">
+            <input
+                class="input inline-width input-light mg-btm-md"
+                placeholder="Search user..."
+                name="search"
+                :value="search"
+            />
+            <input type="hidden" name="page" value="1" />
+        </form>
         <div class="leader-overflow">
             <div class="table-wrap mg-btm-md">
                 <v-table
@@ -122,7 +126,8 @@
 export default {
     props: {
         leaderboard: Array,
-        houseguests: Array
+        houseguests: Array,
+        search: String
     },
     data: () => ({
         filters: {

--- a/resources/js/components/leaderboard/LeaderboardTable.vue
+++ b/resources/js/components/leaderboard/LeaderboardTable.vue
@@ -9,6 +9,7 @@
                 :value="search"
             />
             <input type="hidden" name="page" value="1" />
+            <button type="submit" class="button-base primary mg-btm-lg">Search</button>
         </form>
         <div class="leader-overflow">
             <div class="table-wrap mg-btm-md">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,10 +14,10 @@
         <link rel="icon" href="/favicon-dev.ico" type="image/x-icon"/>
     @endif
 <!-- Scripts -->
-    <script src="{{ asset('js/app.js') }}" defer></script>
+    <script src="{{ mix('js/app.js') }}" defer></script>
 
     <!-- Styles -->
-    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+    <link href="{{ mix('css/app.css') }}" rel="stylesheet">
 </head>
 <body>
 <div id="app" class="app-wrapper">

--- a/resources/views/leaderboard.blade.php
+++ b/resources/views/leaderboard.blade.php
@@ -5,7 +5,10 @@
         <h3 class="mg-btm-lg">{{ $season->name }} Leaderboard</h3>
             <leaderboard-table
                 :houseguests="{{ $houseguests }}"
-                :leaderboard="{{ $leaderboard }}"
+                :leaderboard="{{ json_encode($leaderboard->toArray()['data']) }}"
+                search="{{ request()->get('search') }}"
             ></leaderboard-table>
     </div>
+
+    {{ $leaderboard->appends(['search' => request()->get('search')])->links() }}
 @endsection

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -3,6 +3,7 @@ const mix = require('laravel-mix');
 mix.js('resources/js/app.js', 'public/js')
    .less('resources/less/app.less', 'public/css')
    .less('resources/less/nova.less', 'public/css')
+   .version();
 
 mix.browserSync({
     proxy: process.env.MIX_BROWSER_SYNC_PROXY


### PR DESCRIPTION
Adjusted leaderboards to paginate server side. This should reduce page load significantly. 

@langermank I looked at the docs for the table component but it doesn't look like it supports paginating via ajax requests with the server. Correct me if I am wrong!

Also in PR: Mix compiles with cache busting.